### PR TITLE
Update all-master

### DIFF
--- a/vagrant/all-master
+++ b/vagrant/all-master
@@ -4,6 +4,7 @@ mv /tmp/assets /assets
 echo 'source <(kubectl completion bash 2>/dev/null)' >>/etc/bash_completion.d/kubectl
 echo 'source <(oc completion bash 2>/dev/null)' >>/etc/bash_completion.d/oc
 echo 'alias k=kubectl' >>/root/.bashrc
+echo "alias watch='watch '" >>/root/.bashrc
 echo 'complete -F __start_kubectl k' >>/root/.bashrc
 cat <<EOF >/etc/exports
 / 10.0.0.0/8(rw,no_root_squash)


### PR DESCRIPTION
Aliasing "watch" to "watch " allows watch commands to expand other aliases, suck as k -> kubectl.